### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_GNU_SOURCE
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_GREP
-date=`date +'%Y-%m-%d'`
+date=`date -u -r ChangeLog +'%Y-%m-%d'`
 AC_SUBST([date])dnl
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile mgrep.1])


### PR DESCRIPTION
Use ChangeLog date instead of build date in `mgrep.1`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Also use UTC to be independent of timezone.

This date call works with GNU date and BSD date.